### PR TITLE
Remove dirspec dependency and replace with in-house alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A python library for interacting with MoMo devices.
 ## Installation
 
 ```
-pip install --allow-external intelhex --allow-unverified intelhex --allow-external dirspec --allow-unverified dirspec pymomo
+pip install --allow-external intelhex --allow-unverified intelhex pymomo
 ```
 
-Pymomo currently relies on two non-PyPI packages, `intelhex` and `dirspec`.  This should change soon.
+Pymomo currently relies on one non-PyPI package, `intelhex`.  This should change soon.
 
 To build MoMo firmware you must also install [SCons](http://www.scons.org/)* and [two Microchip compilers](http://www.microchip.com/pagehandler/en_us/devtools/mplabxc/) - XC8 and XC16
 

--- a/pymomo/utilities/paths.py
+++ b/pymomo/utilities/paths.py
@@ -3,6 +3,8 @@ import os.path
 import sys
 import subprocess
 import functools
+import platform
+import os
 
 from pkg_resources import resource_filename, Requirement
 
@@ -25,6 +27,36 @@ class MomoPaths:
 		self.templates = os.path.join(self.config, 'templates')
 		self.pcb = os.path.join(self.base, 'pcb')
 		self.site_tools = os.path.join(self.config, 'site_scons')
+		self.settings = self._find_settings_dir()
+
+	def _find_settings_dir(self):
+		"""
+		Find a per user settings directory that is appropriate for each
+		type of system that we are installed on.
+		"""
+
+		system = platform.system()
+
+		basedir = None
+
+		if system == 'Windows':
+			if 'APPDATA' in os.environ:
+				basedir = os.environ['APPDATA']
+		elif system == 'Darwin':
+			basedir = os.path.expanduser('~/Library/Preferences')
+
+		#If we're not on Windows or Mac OS X, assume we're on some
+		#kind of posix system where the appropriate place would be
+		#~/.config
+		if basedir is None:
+			basedir = os.path.expanduser('~')
+			basedir = os.path.join(basedir, '.config')
+
+		settings_dir = os.path.abspath(os.path.join(basedir, 'WellDone-MoMo'))
+		if not os.path.exists(settings_dir):
+			os.makedirs(settings_dir, 0755)
+
+		return settings_dir
 
 	def select(self, *args, **kwargs):
 		"""

--- a/pymomo/utilities/rcfile.py
+++ b/pymomo/utilities/rcfile.py
@@ -3,8 +3,8 @@
 #It uses dirspec to find the appropriate config directory for each platform and
 #then creates a file under that directory with the appropriate application name
 
-from dirspec.basedir import get_xdg_config_home
 import os.path
+from paths import MomoPaths
 from pymomo.exceptions import *
 
 class RCFile:
@@ -38,10 +38,11 @@ class RCFile:
 			self.contents = []
 
 	def _build_path(self):
-		dname = get_xdg_config_home()
+		paths = MomoPaths()
+		
 		fname = "%s_config.txt" % self.name
 
-		return os.path.join(dname, fname)
+		return os.path.join(paths.settings, fname)
 
 	def save(self):
 		"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,4 @@
 
 --allow-external intelhex
 --allow-unverified intelhex
---allow-external dirspec
---allow-unverified dirspec
 -e .

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
         "cmdln==1.1.2",
         "colorama==0.3.3",
         "decorator==3.4.0",
-        "dirspec==13.10",
         "intelhex==1.5",
         "Markdown==2.5.2",
         "nose==1.3.4",

--- a/test/test_utilities/test_settings_dir.py
+++ b/test/test_utilities/test_settings_dir.py
@@ -1,0 +1,41 @@
+from pymomo.utilities import build
+from nose.tools import *
+import unittest
+import os.path
+import os
+import platform
+from pymomo.exceptions import *
+from pymomo.utilities.paths import MomoPaths
+
+class TestSettingsDirectory:
+	def setUp(self):
+		self.paths = MomoPaths()
+		self.confdir = os.path.join(os.path.expanduser('~'), '.config')
+
+	def test_settings_dir(self):
+		assert os.path.exists(self.paths.settings)
+
+	@unittest.skipIf(platform.system() != 'Linux', 'Linux specific test')
+	def test_settings_linix(self):
+		settings_dir = os.path.abspath(os.path.join(self.confdir, 'WellDone-MoMo'))
+
+		assert settings_dir == self.paths.settings
+
+	@unittest.skipIf(platform.system() != 'Windows', 'Windows specific test')
+	def test_settings_windows(self):
+		if 'APPDATA' in os.environ:
+			base = os.environ['APPDATA']
+		else:
+			base = self.confdir
+
+		settings_dir = os.path.abspath(os.path.join(base, 'WellDone-MoMo'))
+
+		assert settings_dir == self.paths.settings
+
+	@unittest.skipIf(platform.system() != 'Darwin', 'Mac OS X specific test')
+	def test_settings_darwin(self):
+
+		settings_dir = os.path.abspath(os.path.join(os.path.expanduser('~'), 'Library', 'Preferences',
+															'WellDone-MoMo'))
+
+		assert settings_dir == self.paths.settings


### PR DESCRIPTION
This PR removes the dependency of pymomo on dirspec, updates the README to remove any mention of dirspec and adds unit tests for mac os x, windows and linux.  These tests were run on a mac, windows and ubuntu computer to verify that they work.