### PR TITLE
Automatically test that pymomo can build MoMo-Firmware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,7 @@ python:
 install:
 - ./test/install.sh
 script: 
-- source ~/.profile
-- export MOMOPATH=.
-- nosetests -w test
-- momo help
-- momo-mod help
-- momo-mib help
-- momo-hex help
-- momo-gsm help
-#- momo-pcb help #(help currently not supported)
-- momo-reportinator help
-- momo-sensor help
-- momo-multisensor help
-#- momo-picunit help #(help currently not supported)
+- ./test/run_tests.sh
 deploy:
   provider: pypi
   user: welldone

--- a/pymomo/hex/controllerblock.py
+++ b/pymomo/hex/controllerblock.py
@@ -1,5 +1,4 @@
 #controllerblock.py
-from pymomo.utilities.typedargs.types import *
 from pymomo.exceptions import *
 from pymomo.utilities.typedargs.annotate import *
 from hexfile import HexFile

--- a/test/install.sh
+++ b/test/install.sh
@@ -5,73 +5,30 @@ set -e
 
 sudo apt-get update
 sudo apt-get install -y libc6:i386 lib32stdc++6 gpsim
-sudo apt-get install -y python python-setuptools python-dev python-pip
-easy_install -U pip
+sudo apt-get install -y python python-dev
+sudo apt-get install -y git
+wget https://bootstrap.pypa.io/get-pip.py -O - | python
 
 if [ -n "$TRAVIS" ]; then
-	MOMOROOT=`pwd`
-	DOWNLOADCACHE="~/.cached_downloads"
+	PYMOMOROOT=`pwd`
 else # VAGRANT
-	MOMOROOT="/vagrant"
+	PYMOMOROOT="/vagrant"
 	HOME="/home/vagrant"
-	DOWNLOADCACHE="/vagrant/.cached_downloads"
-
-	echo "Adding user 'vagrant' to the group 'dialout' so it can access USB devices..."
-	usermod vagrant -a -G dialout
-	echo "DONE!"
 fi
-echo "MOMOROOT=$MOMOROOT" >> $HOME/.profile
-mkdir -p $DOWNLOADCACHE
 
-download_file () {
-	NAME=$1
-	URL=$2
-	FILE=`basename $URL`
-	EXPECTEDSHA=$3
-  if [ -e $DOWNLOADCACHE/$FILE ]; then
-		echo "Found cached $NAME!"
-		cp $DOWNLOADCACHE/$FILE .
-	else
-		echo "Downloading $NAME"
-		wget $URL
-		SHA=`openssl sha256 ./$FILE`
-		if [ "$SHA" = "SHA256(./$FILE)= $EXPECTEDSHA" ]; then
-			cp ./$FILE $DOWNLOADCACHE
-		else
-			#rm -f ./$FILE
-			die "Invalid downloaded file hash, exiting!"
-		fi
-	fi
-}
+cd $HOME
+rm -rf ./MoMo-Firmware
+git clone https://github.com/welldone/MoMo-Firmware.git
 
-XC8VERSION=v1.33
-XC8INSTALLER=xc8-$XC8VERSION-full-install-linux-installer.run
-download_file "XC8 Installer"	http://ww1.microchip.com/downloads/en/DeviceDoc/$XC8INSTALLER 5bdfbafbe1fb4f2d47a7dacc60d918a0b54425bc02a0ffe352ab4ad02c70143a
-echo "Installing xc8 compiler..."
-chmod +x ./$XC8INSTALLER
-sudo ./$XC8INSTALLER --mode unattended --netservername "" --prefix "/opt/microchip/xc8/$XC8VERSION"
-CODE=$?
-echo "export PATH=\"\$PATH:/opt/microchip/xc8/$XC8VERSION/bin\"" >> $HOME/.profile
-rm -f ./$XC8INSTALLER $XC8INSTALLER.tar
-if [ $CODE -ne 0 ]; then
-	die "Failed to install xc8, exiting!"
-fi
-echo "DONE!"
+MOMOPATH=$HOME/MoMo-Firmware
+cd $MOMOPATH
+sudo MOMO_DEV=true SKIP_PYMOMO_INSTALLATION=true MOMOPATH=$MOMOPATH ./tools/automation/provision.sh
 
-XC16VERSION=v1.21
-XC16INSTALLER=xc16-$XC16VERSION-linux-installer.run
-download_file "XC16 Installer" http://ww1.microchip.com/downloads/en/DeviceDoc/$XC16INSTALLER.tar 80a9fcc6e9e8b051266e06c1eff0ca078ebbc791a7d248dedd65f34a76d7735c
-tar -xvf $XC16INSTALLER.tar
-echo "Installing xc16 compiler..."
-sudo ./$XC16INSTALLER --mode unattended --netservername "" --prefix "/opt/microchip/xc16/$XC16VERSION"
-CODE=$?
-echo "export PATH=\"\$PATH:/opt/microchip/xc16/$XC16VERSION/bin\"" >> $HOME/.profile
-rm -f ./$XC16INSTALLER ./$XC16INSTALLER.tar
-if [ $CODE -ne 0 ]; then
-	die "Failed to install xc16, exiting!"
-fi
-echo "DONE!"
+echo "MOMOPATH=$MOMOPATH" >> $HOME/.profile
 
-cd $MOMOROOT
-pip install http://downloads.sourceforge.net/project/scons/scons/2.3.4/scons-2.3.4.tar.gz --egg
+cd $PYMOMOROOT
+pip install http://sourceforge.net/projects/scons/files/latest/download --egg | tee -a $HOME/scons-install.log
+PYTHONPATH=`cat $HOME/scons-install.log | grep ' library modules ' | awk '{print $6}'`
+echo "export PYTHONPATH=$PYTHONPATH" >> $HOME/.profile
+
 pip install -r requirements.txt

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,0 +1,22 @@
+set -e
+
+source ~/.profile
+nosetests -w test
+
+momo help
+momo-mod help
+momo-mib help
+momo-hex help
+momo-gsm help
+#momo-pcb help #(help currently not supported)
+momo-reportinator help
+momo-sensor help
+momo-multisensor help
+#momo-picunit help #(help currently not supported)
+
+sudo chown -R $USER:$USER $MOMOPATH
+cd $MOMOPATH
+echo "Testing MoMo build..."
+echo `pwd`
+./tools/automation/build_all.sh
+echo "DONE!"


### PR DESCRIPTION
This should prevent unwanted errors, with the side effect being that the pymomo Travis builds will take longer.